### PR TITLE
cordova-plugin-geolocation version older version

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -26,5 +26,5 @@
         <allow-intent href="itms-apps:*" />
     </platform>
     <plugin name="cordova-plugin-whitelist" spec="https://github.com/apache/cordova-plugin-whitelist" />
-    <plugin name="cordova-plugin-geolocation" spec="https://github.com/apache/cordova-plugin-geolocation" />
+    <plugin name="cordova-plugin-geolocation" spec="2.4.3" />
 </widget>


### PR DESCRIPTION
On the buildfarm there is cordova-android 5.2, we need older version of the plugin, which still supports this version